### PR TITLE
Revert "if PR does not have assignee, prevent crash from error of Cannot read property 'login' of null"

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ try {
   // Get the JSON webhook payload for the event that triggered the workflow
   const payload = JSON.stringify(github.context.payload, undefined, 2)
   console.log(`The event payload: ${payload}`);
-  const assignee = JSON.stringify(github.context.payload.pull_request.assignee?.login)
+  const assignee = JSON.stringify(github.context.payload.pull_request.assignee.login)
   console.log(`The assignee is ${assignee}`);
   core.setOutput("assignee", assignee);
 } catch (error) {


### PR DESCRIPTION

This reverts commit 23ad72351bff91adae1032f1a81f1dac7f4cb375.